### PR TITLE
Default auth_type to 'moopa' for untagged routes

### DIFF
--- a/tables/moo_route.cfc
+++ b/tables/moo_route.cfc
@@ -124,7 +124,7 @@ TODO: need to check if old way works for the following and which has precedence:
                 <cfset stRoute.endpoints = {} />
                 <cfset stRoute.md = duplicate(getMetaData(createObject("component", "#stRoute.componentPath#"))) />
                 <cfset stRoute['open_to'] = stRoute.md['open_to']?:'security' /> <!--- public,bearer,logged_in,security --->
-                <cfset stRoute['auth_type'] = stRoute.md['auth_type']?:stRoute.md['auth']?:'' />
+                <cfset stRoute['auth_type'] = stRoute.md['auth_type']?:stRoute.md['auth']?:'moopa' />
 
                 <!--- Need to determine if the route is already defined --->
 


### PR DESCRIPTION
## Summary

- Routes without an explicit `auth_type` attribute now default to `moopa` instead of an empty string
- This tightens the default from "unrestricted" (any auth type allowed) to "restricted" (moopa auth type required)
- Routes that already set `auth_type` are completely unaffected
- Endpoint-level `auth_type` inheritance (line 140) is also unaffected — endpoints inherit from the route, which now defaults to `moopa`

## Rationale

The previous empty-string default meant untagged routes had no auth domain restriction. In practice, routes without an explicit `auth_type` are framework and admin routes — defaulting them to `moopa` matches their actual intent and is the safer direction (restrictive by default, opt-out to open).

## Test plan

- [ ] Verify routes with explicit `auth_type` are unaffected
- [ ] Verify untagged routes now report `auth_type = 'moopa'` in route data
- [ ] Verify `checkAccess()` enforces moopa auth type on untagged routes for logged-in users
- [ ] Verify public routes (`open_to="public"`) still pass access checks regardless of auth_type