### PR TITLE
Render 500 page debug output explicitly

### DIFF
--- a/application.cfc
+++ b/application.cfc
@@ -406,7 +406,9 @@
                 <p class="h2 fw-normal mt-3 mb-4">Administrators have been notififed.</p>
                 <p class="h2 fw-normal mt-3 mb-4">You could try again or wait for us to get in touch.</p>
                 <div class="">
-                    <a href="#url.route?:''#" class="btn btn-outline-primary btn-lg" id="try-again-button">Try Again</a>
+                    <cfoutput>
+                    <a href="#encodeForHTMLAttribute(url.route?:'')#" class="btn btn-outline-primary btn-lg" id="try-again-button">Try Again</a>
+                    </cfoutput>
 
                     <a href="/" class="btn btn-primary btn-lg" id="try-again-button">Return home</a>
                 </div>
@@ -415,11 +417,15 @@
                 <cfif (server.system.environment.APP_ENVIRONMENT?:'production') EQ 'development' OR (url.debug?:'') EQ (server.system.environment.DEBUG_KEY?:createUUID())>
                     <hr>
 
-                    <p class="h1">#arguments.exception.message?:''#.</p>
+                    <cfoutput>
+                    <p class="h1">#encodeForHTML(arguments.exception.message?:'')#.</p>
+                    </cfoutput>
                     <hr>
                     <cfif arrayLen(arguments.exception.tagContext?:[])>
                         <cfloop array="#arguments.exception.tagContext#" item="item">
-                            <h4 class="text-lg text-start">From: #item.template#:#item.line# </h4>
+                            <cfoutput>
+                            <h4 class="text-lg text-start">From: #encodeForHTML(item.template?:'')#:#encodeForHTML(item.line?:'')# </h4>
+                            </cfoutput>
                         </cfloop>
                     </cfif>
 


### PR DESCRIPTION
## Summary
- wrap the 500 page retry URL, exception message, and tag-context rows in explicit `cfoutput` blocks
- HTML-encode the debug message and tag-context values, and attribute-encode the retry URL

## Root cause
The development 500 template had `#...#` expressions in plain markup. Lucee is permissive enough here that the values render, but RustCFML leaves them literal unless they are inside `cfoutput`. That made the error page show raw variables like `#arguments.exception.message#` and `#item.template#:#item.line#` while debugging a database connection failure.

## Validation
- `git diff --check`
- inspected the rendered-output paths in `application.cfc` for explicit output and HTML encoding

## Notes
This intentionally changes only the diagnostic rendering path. It does not change error handling or routing behavior.