### PR TITLE
Remove first-run setup gate from framework core

### DIFF
--- a/application.cfc
+++ b/application.cfc
@@ -198,9 +198,6 @@
         </cfif>
 
 
-        <cfset _redirectToHubSetupIfNeeded() />
-
-
         <!--- --------------------------------- --->
         <!--- LETS SEE IF WE NEED TO AUTO LOGIN --->
         <!--- --------------------------------- --->
@@ -553,55 +550,6 @@
                 <cfset arguments.target[local.componentName] = CreateObject("component", local.componentPath).init() />
             </cfloop>
         </cfloop>
-    </cffunction>
-
-
-    <cffunction name="_redirectToHubSetupIfNeeded" access="private" returntype="void" output="false">
-        <cfset var currentRoute = url.route ?: "/" />
-        <cfset var currentApp = application.app_name ?: "" />
-        <cfset var isHubSetupRoute = (currentApp EQ "hub" AND reFindNoCase("^/setup/?$", currentRoute)) />
-        <cfset var isHubInstallRoute = (currentApp EQ "hub" AND reFindNoCase("^/install/?$", currentRoute)) />
-        <cfset var needsSetup = false />
-        <cfset var hubSetupUrl = "" />
-        <cfset var hubBaseUrl = "" />
-
-        <cfif isHubSetupRoute OR isHubInstallRoute OR NOT structKeyExists(application, "lib") OR NOT structKeyExists(application.lib, "core")>
-            <cfreturn />
-        </cfif>
-
-        <cftry>
-            <cfset needsSetup = application.lib.core.requiresHubSetup() />
-            <cfcatch type="database">
-                <cfset needsSetup = true />
-            </cfcatch>
-        </cftry>
-
-        <cfif NOT needsSetup>
-            <cfreturn />
-        </cfif>
-
-        <cfset hubBaseUrl = trim(server.system.environment.HUB_BASE_URL ?: "") />
-
-        <cfif NOT len(hubBaseUrl)>
-            <cfif currentApp EQ "hub">
-                <cfset hubBaseUrl = "" />
-            <cfelse>
-                <cfthrow type="moopa.configuration.missingHubBaseUrl" message="HUB_BASE_URL is required to redirect non-hub apps to Hub setup." />
-            </cfif>
-        <cfelseif NOT reFindNoCase("^https?://", hubBaseUrl)>
-            <cfthrow type="moopa.configuration.invalidHubBaseUrl" message="HUB_BASE_URL must be an absolute http(s) URL." />
-        </cfif>
-
-        <cfset hubSetupUrl = reReplace(hubBaseUrl, "/+$", "", "one") & "/setup/" />
-
-        <cfif structKeyExists(getHttpRequestData().headers, "X-Fetch-Request") AND getHttpRequestData().headers["X-Fetch-Request"] EQ "true">
-            <cfheader statuscode="409" statustext="Setup Required">
-            <cfcontent type="application/json" reset="true">
-            <cfoutput>#serializeJSON({error: "Setup required", setup_url: hubSetupUrl})#</cfoutput>
-            <cfabort>
-        </cfif>
-
-        <cflocation url="#hubSetupUrl#" addtoken="false" />
     </cffunction>
 
 

--- a/lib/core.cfc
+++ b/lib/core.cfc
@@ -223,37 +223,6 @@
     </cffunction>
 
 
-    <cffunction name="requiresHubSetup" access="public" output="false" returntype="boolean">
-        <cfset var sysadminEmails = "" />
-        <cfset var sysadminEmail = "" />
-
-        <cfloop list="#server.system.environment.SYSADMIN_EMAIL ?: ''#" item="sysadminEmail">
-            <cfset sysadminEmail = lCase(trim(sysadminEmail)) />
-            <cfif len(sysadminEmail)>
-                <cfset sysadminEmails = listAppend(sysadminEmails, sysadminEmail) />
-            </cfif>
-        </cfloop>
-
-        <cfif NOT hasMoopaProfileTable()>
-            <cfreturn true />
-        </cfif>
-
-        <cfif NOT len(sysadminEmails)>
-            <cfreturn true />
-        </cfif>
-
-        <cfquery name="local.qProfiles">
-            SELECT count(*) AS profile_count
-            FROM moo_profile
-            WHERE app_name = <cfqueryparam cfsqltype="varchar" value="hub" />
-            AND can_login = true
-            AND lower(email) IN (<cfqueryparam cfsqltype="varchar" value="#sysadminEmails#" list="true" />)
-        </cfquery>
-
-        <cfreturn val(local.qProfiles.profile_count) EQ 0 />
-    </cffunction>
-
-
 
 
     <cffunction name="logError" returntype="void" output="true">


### PR DESCRIPTION
## Why
The per-request setup gate (`_redirectToHubSetupIfNeeded()`) ran **two uncached DB queries on every request of every app, forever** — a `moo_profile` existence probe plus a sysadmin-count query. Profiling a plain anonymous homepage found this was ~42ms of the request (two serial DB round-trips) before any route logic ran, even though setup is a one-time concern that can never revert once done. The framework should not carry an always-on tax for a bootstrapping step.

## Summary
- Remove `_redirectToHubSetupIfNeeded()` and its call site in `_moopa()` (`application.cfc`).
- Remove `requiresHubSetup()` from `lib/core.cfc` (its only caller was the gate above).
- Keep `hasMoopaProfileTable()` / `hasSystemProfile()` — general utilities still used by app/shared code (auth, the setup route).

Setup now lives entirely in the **starter** as deletable scaffolding (app-level `OnRequestStart` hook + `setup_gate.cfc` + `finalize-setup` tooling), so a real project sheds it after the first boot.

## Test plan
- [x] Anonymous www homepage on RustCFML: TTFB ~73ms → ~33ms after removal.
- [x] Hub `/login/` still returns 302 (no errors from removed gate).
- [ ] Fresh/unprovisioned environment relies on the starter gate (or `/schema/` deploy path) to reach setup — confirm in a clean DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)