### PR TITLE
feat(controls): render required marker from table-def nullable

### DIFF
--- a/controls/text.cfm
+++ b/controls/text.cfm
@@ -4,6 +4,7 @@
     <cfparam name="attributes.model" default="" />
     <cfparam name="attributes.class" default="input w-full" />
     <cfparam name="attributes.placeholder" default="" />
+    <cfparam name="attributes.required" type="boolean" default="false" />
 
     <cfoutput>
         <input id="#attributes.id#"
@@ -11,6 +12,7 @@
             class="#attributes.class#"
             placeholder="#attributes.placeholder#"
             x-model="#attributes.model#"
+            <cfif attributes.required>aria-required="true"</cfif>
         >
     </cfoutput>
 

--- a/controls/textarea.cfm
+++ b/controls/textarea.cfm
@@ -5,6 +5,7 @@
     <cfparam name="attributes.placeholder" default="" />
     <cfparam name="attributes.rows" default="3" />
     <cfparam name="attributes.id" default="" />
+    <cfparam name="attributes.required" type="boolean" default="false" />
 
     <cfoutput>
         <textarea
@@ -13,6 +14,7 @@
             placeholder="#attributes.placeholder#"
             x-model="#attributes.model#"
             <cfif len(attributes.id)>id="#attributes.id#"</cfif>
+            <cfif attributes.required>aria-required="true"</cfif>
         ></textarea>
     </cfoutput>
 

--- a/tags/control.cfm
+++ b/tags/control.cfm
@@ -91,7 +91,7 @@ packages overriding core Moopa controls.
     <cfif len(attributes.label)>
         <cfif attributes.label_position EQ "left">
             <div class="flex items-center gap-4">
-                <label for="#control_attrs.id#" class="w-1/4">#attributes.label#</label>
+                <label for="#control_attrs.id#" class="w-1/4">#attributes.label#<cfif attributes.required> <span class="text-error" aria-hidden="true">*</span></cfif></label>
                 <div class="flex-1">
                     <cfmodule
                         template="#control_template#"
@@ -101,7 +101,7 @@ packages overriding core Moopa controls.
             </div>
         <cfelse>
             <fieldset class="#attributes.class#">
-                <legend class="fieldset-legend">#attributes.label#</legend>
+                <legend class="fieldset-legend">#attributes.label#<cfif attributes.required> <span class="text-error" aria-hidden="true">*</span></cfif></legend>
                 <cfmodule
                     template="#control_template#"
                     attributecollection="#control_attrs#"

--- a/tags/table_controls.cfm
+++ b/tags/table_controls.cfm
@@ -52,6 +52,13 @@ Delegates actual rendering to <cf_control>.
         <!--- Set label from table definition unless the UI metadata overrides it. --->
         <cfset control_attrs.label = control_attrs.label ?: field_def.label ?: "" />
 
+        <!--- Derive required-ness from the schema: a non-nullable column is
+              required, unless the UI metadata explicitly overrides it
+              (html.required: true to force, false to suppress). cf_control
+              renders the marker and the per-control templates the aria/native
+              attribute. --->
+        <cfset control_attrs.required = control_attrs.required ?: (NOT (field_def.nullable ?: true)) />
+
         <!--- Auto-generate model path. --->
         <cfset control_attrs.model = "#attributes.model_record#.#field_name#" />
 

--- a/tags/table_controls.cfm
+++ b/tags/table_controls.cfm
@@ -54,10 +54,13 @@ Delegates actual rendering to <cf_control>.
 
         <!--- Derive required-ness from the schema: a non-nullable column is
               required, unless the UI metadata explicitly overrides it
-              (html.required: true to force, false to suppress). cf_control
-              renders the marker and the per-control templates the aria/native
-              attribute. --->
-        <cfset control_attrs.required = control_attrs.required ?: (NOT (field_def.nullable ?: true)) />
+              (html.required: true to force, false to suppress). Only honour the
+              override when it's an actual boolean — a stray non-boolean string
+              must never reach cf_control's `cfparam type="boolean"`, where a cast
+              throw would take down every form in the app (these are framework
+              tags). cf_control renders the marker and the per-control templates
+              the aria attribute. --->
+        <cfset control_attrs.required = isBoolean(control_attrs.required ?: "") ? control_attrs.required : (NOT (field_def.nullable ?: true)) />
 
         <!--- Auto-generate model path. --->
         <cfset control_attrs.model = "#attributes.model_record#.#field_name#" />


### PR DESCRIPTION
## Why
Forms built with `cf_table_controls` (used across Real Easy's Agent + Hub portals) show **no required-field indicators** — users only discover a field is required from a save-error. A UX review surfaced it on the agent "New Agent" modal, but it's framework-wide. The schema already knows which fields are required (`nullable:false`), so the framework can mark them automatically.

Scoped from realeasycode/hello#355.

## Summary
- **`tags/table_controls.cfm`** — derive `control_attrs.required` from the schema: a `nullable:false` column is required, unless `html.required` overrides it (`true` to force, `false` to suppress). Respects an explicit per-field config override.
- **`tags/control.cfm`** — `attributes.required` was declared but never rendered; now appends a `*` (`text-error`, `aria-hidden`) after the label in both the left-label and top-legend layouts.
- **`controls/text.cfm`, `controls/textarea.cfm`** — emit `aria-required="true"` when required.

Opt-in and backward compatible: any `nullable:true` field renders exactly as before. The `*` is rendered by `cf_control`'s label wrapper, so it appears for every control type uniformly; per-input `aria-required` is added to text/textarea here, with the remaining control templates (email, currency, date, url, password, switch, checkbox) to follow the same one-line pattern.

## Test plan
- [ ] A `nullable:false` field rendered via `cf_table_controls` shows a `*` and (text/textarea) `aria-required="true"`.
- [ ] `html.required: false` suppresses it; `html.required: true` forces it on a `nullable:true` field.
- [ ] Agent New Agent modal: first/last name show `*`; email (nullable:true) does not.
- [ ] Existing forms unchanged apart from the added markers; no layout breakage at `left` and `top` label positions.

> Not yet browser-verified against a running app (developed in an isolated submodule worktree; the live local stack runs off the pinned submodule commit). Static review only — verify by bumping the submodule on a hello branch, or a temporary local apply, before merge.
