### PR TITLE
fix(sysadmin): app-scoped route-security profiles + duplicate-aware sysadmin protection

### DIFF
--- a/routes/sysadmin/profiles.cfc
+++ b/routes/sysadmin/profiles.cfc
@@ -78,7 +78,20 @@
         </cfif>
 
         <cfset profile = getProfileSysadminIdentity(arguments.profile_id) />
-        <cfreturn structKeyExists(profile, "id") AND isConfiguredHubSysadminEmail(profile.email ?: "", profile.app_name ?: "") />
+        <cfif NOT (structKeyExists(profile, "id") AND isConfiguredHubSysadminEmail(profile.email ?: "", profile.app_name ?: ""))>
+            <cfreturn false />
+        </cfif>
+
+        <!--- Duplicate rows for the same sysadmin email (e.g. stale pre-migration profiles)
+              stay editable/deletable: only the sole remaining row is protected. --->
+        <cfquery name="local.qDuplicates" returntype="array">
+            SELECT count(*)::int AS profile_count
+            FROM moo_profile
+            WHERE app_name = 'hub'
+              AND lower(email) = lower(<cfqueryparam cfsqltype="varchar" value="#profile.email#" />)
+        </cfquery>
+
+        <cfreturn local.qDuplicates[1].profile_count LTE 1 />
     </cffunction>
 
 
@@ -102,6 +115,14 @@
                 (
                     moo_profile.app_name = 'hub'
                     AND lower(moo_profile.email) IN (<cfqueryparam cfsqltype="varchar" value="#getSysadminEmailList()#" list="true" />)
+                    <!--- Duplicate rows for the same sysadmin email (e.g. stale pre-migration
+                          profiles) stay deletable: only the sole remaining row is protected. --->
+                    AND (
+                        SELECT count(*)
+                        FROM moo_profile dup
+                        WHERE dup.app_name = 'hub'
+                          AND lower(dup.email) = lower(moo_profile.email)
+                    ) = 1
                 ) AS is_configured_sysadmin,
                 COUNT(*) OVER() AS total_count,
                 COALESCE((
@@ -303,7 +324,10 @@
                                         <button class="btn btn-ghost btn-sm btn-square min-h-10 h-10 w-10" @click.stop="select(item)" title="Edit profile" aria-label="Edit profile">
                                             <i class="fa-solid fa-pen-to-square text-base-content/70"></i>
                                         </button>
-                                        <button class="btn btn-ghost btn-sm btn-square min-h-10 h-10 w-10 text-error" @click.stop="openDeleteModal(item)" title="Delete profile" :disabled="isProtectedSysadmin(item)" :aria-label="isProtectedSysadmin(item) ? 'Configured Hub sysadmin profiles cannot be deleted' : 'Delete profile'">
+                                        <!--- Not :disabled — daisyUI disabled buttons get pointer-events:none, so the click
+      would fall through to the row and open the drawer. Keep it clickable and let
+      openDeleteModal toast the protected explanation instead. --->
+                                        <button class="btn btn-ghost btn-sm btn-square min-h-10 h-10 w-10 text-error" :class="isProtectedSysadmin(item) && 'opacity-40 cursor-not-allowed'" @click.stop="openDeleteModal(item)" title="Delete profile" :aria-disabled="isProtectedSysadmin(item)" :aria-label="isProtectedSysadmin(item) ? 'Configured Hub sysadmin profiles cannot be deleted' : 'Delete profile'">
                                             <i class="fa-solid fa-trash"></i>
                                         </button>
                                     </div>
@@ -428,7 +452,7 @@
                                                 <button class="btn btn-ghost btn-sm btn-square min-h-9 h-9 w-9" @click.stop="select(item)" title="Edit profile" aria-label="Edit profile">
                                                     <i class="fa-solid fa-pen-to-square text-base-content/70"></i>
                                                 </button>
-                                                <button class="btn btn-ghost btn-sm btn-square min-h-9 h-9 w-9 text-error" @click.stop="openDeleteModal(item)" title="Delete profile" :disabled="isProtectedSysadmin(item)" :aria-label="isProtectedSysadmin(item) ? 'Configured Hub sysadmin profiles cannot be deleted' : 'Delete profile'">
+                                                <button class="btn btn-ghost btn-sm btn-square min-h-9 h-9 w-9 text-error" :class="isProtectedSysadmin(item) && 'opacity-40 cursor-not-allowed'" @click.stop="openDeleteModal(item)" title="Delete profile" :aria-disabled="isProtectedSysadmin(item)" :aria-label="isProtectedSysadmin(item) ? 'Configured Hub sysadmin profiles cannot be deleted' : 'Delete profile'">
                                                     <i class="fa-solid fa-trash"></i>
                                                 </button>
                                             </div>

--- a/routes/sysadmin/routes/index.cfc
+++ b/routes/sysadmin/routes/index.cfc
@@ -36,7 +36,9 @@
       <cfreturn application.lib.db.search(table_name='moo_role', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#")/>
     </cffunction>
     <cffunction name="search.current_record.profiles">
-      <cfreturn application.lib.db.search(table_name='moo_profile', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#")/>
+      <!--- Route grants only make sense for profiles that can log into this app,
+            matching the app_name filter on the route list itself. --->
+      <cfreturn application.lib.db.search(table_name='moo_profile', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#", where={"app_name": application.app_name})/>
     </cffunction>
 
     <cffunction name="get">


### PR DESCRIPTION
## Why
The hub Route Security profile picker offered every profile in the system (including hundreds of agent/gday personas), and stale duplicate sysadmin profiles — e.g. Clerk-era remnants from before the Microsoft OAuth migration — were undeletable because the "Protected" guard matches on email alone.

## Summary
- Route Security profile picker (`routes/sysadmin/routes/index.cfc`) now filters `moo_profile` by `application.app_name`, matching the filter already applied to the route list.
- Sysadmin protection (`routes/sysadmin/profiles.cfc`) is duplicate-aware: a configured sysadmin profile is only protected when it is the sole hub profile with that email. Deleting a duplicate leaves the survivor protected. Applied in both the list SQL flag and the server-side save/delete guard.
- Protected rows' delete button is no longer `:disabled` (daisyUI disabled buttons get `pointer-events:none`, so clicks fell through and opened the detail drawer); it stays clickable, dimmed, and toasts the explanation.

## Test plan
- [x] Dev DB: simulated duplicate hub sysadmin in a rolled-back transaction — both duplicates flagged deletable, sole-row sysadmin stays protected
- [x] Local hub restart + health check
- [ ] After deploy: delete stale duplicate hub profile via UI; verify survivor flips back to Protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)