### PR TITLE
fix(sysadmin): app-scope the route detail Edit Route Access profile picker

### DIFF
--- a/routes/sysadmin/routes/[route_id]/index.cfc
+++ b/routes/sysadmin/routes/[route_id]/index.cfc
@@ -313,7 +313,8 @@
         <cfreturn application.lib.db.search(table_name='moo_role', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#") />
     </cffunction>
     <cffunction name="search.profiles">
-        <cfreturn application.lib.db.search(table_name='moo_profile', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#") />
+        <!--- Route grants only make sense for profiles that can log into this app. --->
+        <cfreturn application.lib.db.search(table_name='moo_profile', q="#url.q?:''#", exclude_ids="#url.exclude_ids?:''#", where={"app_name": application.app_name}) />
     </cffunction>
 
 


### PR DESCRIPTION
## Why
Blute/moopa#17 filtered the profile picker on the routes tree page, but the Edit Route Access panel users actually interact with lives on the [route_id] detail route, whose search.profiles endpoint was still unfiltered — so the picker kept offering every profile across all apps.

## Summary
- Apply the same `where={app_name: application.app_name}` filter to `search.profiles` in `routes/sysadmin/routes/[route_id]/index.cfc` (the endpoint the cf_table_controls combobox resolves to).

## Test plan
- [x] Traced cf_table_controls → combobox default endpoint (`search.profiles`) to confirm this is the live picker endpoint
- [ ] Local hub: Edit Route Access picker lists only hub profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)