### PR TITLE
fix: boot parity for stock RustCFML runtime

### DIFF
--- a/lib/cloudflare_stream.cfc
+++ b/lib/cloudflare_stream.cfc
@@ -5,9 +5,9 @@
 
 
     <cffunction name="init">
-        <cfset variables.apiToken = server.system.environment.CLOUDFLARE_STREAM_API_TOKEN />
-        <cfset variables.accountId = server.system.environment.CLOUDFLARE_ACCOUNT_ID />
-        <cfset variables.customerSubdomain = server.system.environment.CLOUDFLARE_CUSTOMER_SUBDOMAIN />
+        <cfset variables.apiToken = server.system.environment.CLOUDFLARE_STREAM_API_TOKEN?:'' />
+        <cfset variables.accountId = server.system.environment.CLOUDFLARE_ACCOUNT_ID?:'' />
+        <cfset variables.customerSubdomain = server.system.environment.CLOUDFLARE_CUSTOMER_SUBDOMAIN?:'' />
     
         <cfreturn this />
     </cffunction>

--- a/lib/db.cfc
+++ b/lib/db.cfc
@@ -2,8 +2,6 @@
 
     <!--- Initialize function for setting up the database connection --->
     <cffunction name="init" access="public" returntype="any" hint="Initialize db with the database connection information.">
-        <!--- <cfargument name="dbinfo" type="struct" required="true" hint="A struct containing the database connection information.">
-        <cfset this.dbOldinfo = arguments.dbOldinfo> --->
 
         <cfset this.codeSchema = {} />
         <cfset this.searchable_tables = {} />

--- a/lib/microsoftud.cfc
+++ b/lib/microsoftud.cfc
@@ -3,10 +3,10 @@
 
     <cffunction name="init">
 
-        <cfset variables.CLIENTID = server.system.environment.MICROSOFT_CLIENTID />
-        <cfset variables.CLIENTSECRET = server.system.environment.MICROSOFT_CLIENTSECRET />
-        <cfset variables.SCOPE = server.system.environment.MICROSOFT_SCOPE />
-        <cfset variables.TENANT = server.system.environment.MICROSOFT_TENANT />
+        <cfset variables.CLIENTID = server.system.environment.MICROSOFT_CLIENTID?:'' />
+        <cfset variables.CLIENTSECRET = server.system.environment.MICROSOFT_CLIENTSECRET?:'' />
+        <cfset variables.SCOPE = server.system.environment.MICROSOFT_SCOPE?:'' />
+        <cfset variables.TENANT = server.system.environment.MICROSOFT_TENANT?:'' />
         <cfset variables.PROXY = server.system.environment.MICROSOFT_PROXY?:'' />
 
         <cfreturn this />


### PR DESCRIPTION
Found while bringing TrackPack up on RustCFML v0.531.0 (stock release binary, moopa-starter shell).

Two small fixes so moopa boots identically on Lucee and stock RustCFML:

1. **db.cfc** — remove the stale commented-out `cfargument dbinfo` block in `init()`. RustCFML v0.531's CFC signature scanner registers a `<cfargument>` inside a `<!--- --->` comment as a live required argument (engine bug, reported separately), which made every boot fail with *"parameter [dbinfo] is required"*. The block is dead code either way.

2. **microsoftud.cfc / cloudflare_stream.cfc** — guard optional env reads with `?:''`. These libs are instantiated unconditionally at lib load; the Lucee Dockerfile bakes in empty `MICROSOFT_*` ENV defaults which masked the unguarded reads, but the stock RustCFML binary (and any bare environment) throws. The `MICROSOFT_PROXY` line already used `?:''` — this makes the rest consistent. Keeps the starter truly bare-bones: no placeholder env vars needed for services you don't use.

Verified: trackpack hub/builder/trade all boot clean on both `make lucee` and `make rust` (v0.531.0) with only DSN + sysadmin env set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)